### PR TITLE
Dependency props in dependency objects

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -51,6 +51,7 @@
     <Compile Include="DemoControl.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DemoDependencyObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/AssemblyToProcess/DemoDependencyObject.cs
+++ b/AssemblyToProcess/DemoDependencyObject.cs
@@ -1,0 +1,15 @@
+﻿namespace AssemblyToProcess.pueblo
+{
+    using System;
+    using System.Windows;
+    using Kasay;
+
+    public class DemoDependencyObject : DependencyObject
+    {
+        [Bind] public String SomeName { get; set; }
+
+        [Bind] public Int32 SomeNumber { get; set; }
+
+        [Bind] public Boolean SomeCondition { get; set; }
+    }
+}

--- a/Kasay.DependencyProperty.WPF.Fody/ModuleWeaver/ConstructorImplementer.cs
+++ b/Kasay.DependencyProperty.WPF.Fody/ModuleWeaver/ConstructorImplementer.cs
@@ -22,19 +22,22 @@ internal class ConstructorImplementer
 
     void EqualDataContext()
     {
-        var method = typeDefinition.GetConstructors().First();
+        if (typeDefinition.InheritFrom("System.Windows.FrameworkElement"))
+        {
+            var method = typeDefinition.GetConstructors().First();
 
-        var callSet_DataContext = presentationAssembly.GetMethodReference("System.Windows.FrameworkElement", "set_DataContext");
+            var callSet_DataContext = presentationAssembly.GetMethodReference("System.Windows.FrameworkElement", "set_DataContext");
 
-        method.Body.Instructions.RemoveAt(method.Body.Instructions.Count - 1);
+            method.Body.Instructions.RemoveAt(method.Body.Instructions.Count - 1);
 
-        var processor = method.Body.GetILProcessor();
-        processor.Emit(OpCodes.Nop);
-        processor.Emit(OpCodes.Ldarg_0);
-        processor.Emit(OpCodes.Ldarg_0);
-        processor.Emit(OpCodes.Call, callSet_DataContext);
-        processor.Emit(OpCodes.Nop);
-        processor.Emit(OpCodes.Ret);
+            var processor = method.Body.GetILProcessor();
+            processor.Emit(OpCodes.Nop);
+            processor.Emit(OpCodes.Ldarg_0);
+            processor.Emit(OpCodes.Ldarg_0);
+            processor.Emit(OpCodes.Call, callSet_DataContext);
+            processor.Emit(OpCodes.Nop);
+            processor.Emit(OpCodes.Ret);
+        }
     }
 
     void AddStaticConstructor()

--- a/Kasay.DependencyProperty.WPF.Fody/ModuleWeaver/ModuleWeaver.cs
+++ b/Kasay.DependencyProperty.WPF.Fody/ModuleWeaver/ModuleWeaver.cs
@@ -24,7 +24,7 @@ public class ModuleWeaver : BaseModuleWeaver
     {
         foreach (var type in ModuleDefinition.GetTypes())
         {
-            if (type.InheritFrom("System.Windows.FrameworkElement"))
+            if (type.InheritFrom("System.Windows.DependencyObject"))
             {
                 new ConstructorImplementer(presentationAssembly, type);
 

--- a/UnitTest/AutoDependencyPropertyDependencyObject_Test.cs
+++ b/UnitTest/AutoDependencyPropertyDependencyObject_Test.cs
@@ -1,20 +1,19 @@
 ﻿using System;
-using Xunit;
-using Fody;
 using System.Windows;
-#pragma warning disable 618
+using Fody;
+using Xunit;
 
-public class AutoDependencyProperty_Test
+public class AutoDependencyPropertyDependencyObject_Test
 {
     readonly Type type;
     readonly dynamic instance;
 
-    public AutoDependencyProperty_Test()
+    public AutoDependencyPropertyDependencyObject_Test()
     {
         var weavingTask = new ModuleWeaver();
         var testResult = weavingTask.ExecuteTestRun("AssemblyToProcess.dll");
 
-        type = testResult.Assembly.GetType("AssemblyToProcess.pueblo.DemoControl");
+        type = testResult.Assembly.GetType("AssemblyToProcess.pueblo.DemoDependencyObject");
         instance = (dynamic)Activator.CreateInstance(type);
     }
 
@@ -29,11 +28,5 @@ public class AutoDependencyProperty_Test
 
         Assert.Equal(value, instance.GetType().GetProperty(propertyName).GetValue(instance));
         Assert.Equal(value, instance.GetValue(dependencyProperty));
-    }
-
-    [Fact]
-    public void DataContext_Test()
-    {
-        Assert.Equal(instance, instance.DataContext);
     }
 }

--- a/UnitTest/AutoDependencyProperty_Test.cs
+++ b/UnitTest/AutoDependencyProperty_Test.cs
@@ -14,7 +14,7 @@ public class AutoDependencyProperty_Test
         var weavingTask = new ModuleWeaver();
         var testResult = weavingTask.ExecuteTestRun("AssemblyToProcess.dll");
 
-        type = testResult.Assembly.GetType("AssemblyToProcess.DemoControl");
+        type = testResult.Assembly.GetType("AssemblyToProcess.pueblo.DemoControl");
         instance = (dynamic)Activator.CreateInstance(type);
     }
 

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="AutoDependencyPropertyDependencyObject_Test.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AutoDependencyProperty_Test.cs" />
   </ItemGroup>


### PR DESCRIPTION
This fixes issue #2; properties in DependencyObjects can now be woven into dependency properties.